### PR TITLE
use closures with preserved names as option handler functions

### DIFF
--- a/src/utils/options.js
+++ b/src/utils/options.js
@@ -1,14 +1,12 @@
-function getOption({ opts }, name, defaultValue = true) {
+const getOption = (name, defaultValue = true) => ({ opts }) => {
   return opts[name] === undefined || opts[name] === null
     ? defaultValue
-    : opts[name]
+    : opts[name] 
 }
 
-export const useDisplayName = state => getOption(state, 'displayName')
-export const useSSR = state => getOption(state, 'ssr', true)
-export const useFileName = state => getOption(state, 'fileName')
-export const useMinify = state => getOption(state, 'minify')
-export const useTranspileTemplateLiterals = state =>
-  getOption(state, 'transpileTemplateLiterals')
-
-export const usePureAnnotation = state => getOption(state, 'pure', false)
+export const useDisplayName = getOption('displayName');
+export const useSSR = getOption('ssr', true);
+export const useFileName = getOption('fileName');
+export const useMinify = getOption('minify');
+export const useTranspileTemplateLiterals = getOption('transpileTemplateLiterals');
+export const usePureAnnotation = getOption('pure', false);


### PR DESCRIPTION
this pr aims to simplify this file in terms of:
- no need to actively declare new functions `state` gets passed to
- no need to pass through `state` down the runtime chain